### PR TITLE
Initialize Spring Boot + Vue2 skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+frontend/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle/
 build/
 frontend/node_modules/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## 백엔드 설정
 
 1. JDK 17 이상을 설치합니다.
-2. 로컬 MySQL 서버를 준비하고 `src/main/resources/application.properties`의 접속 정보를 수정합니다.
+2. 로컬 MySQL 서버를 준비하고 `src/main/resources/application.properties`의 접속 정보를 수정합니다. 기본 서버 포트는 `8080`입니다.
 3. 프로젝트 루트에서 다음 명령으로 테스트 및 빌드를 수행할 수 있습니다.
    ```bash
    gradle build
@@ -14,7 +14,7 @@
 ## 프론트엔드 설정
 
 1. Node.js 16 이상과 npm을 설치합니다.
-2. 프론트엔드 의존성을 설치하고 개발 서버를 실행합니다. 루트에서 다음 명령을 실행하면 자동으로 `frontend` 폴더를 사용합니다.
+2. 프론트엔드 의존성을 설치하고 개발 서버를 실행합니다. 기본 포트는 `8081`이며 `/api` 경로 요청은 백엔드(8080)으로 프록시됩니다. 루트에서 다음 명령을 실행하면 자동으로 `frontend` 폴더를 사용합니다.
    ```bash
    npm install --prefix frontend
    npm run serve

--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@
 ## 프론트엔드 설정
 
 1. Node.js 16 이상과 npm을 설치합니다.
-2. `frontend` 디렉터리에서 의존성을 설치하고 개발 서버를 실행합니다.
+2. 프론트엔드 의존성을 설치하고 개발 서버를 실행합니다. 루트에서 다음 명령을 실행하면 자동으로 `frontend` 폴더를 사용합니다.
    ```bash
-   cd frontend
-   npm install
+   npm install --prefix frontend
    npm run serve
    ```
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # springvue2
-codex와 함께하는 프로젝트
+
+이 프로젝트는 Spring Boot 백엔드와 Vue 2 프론트엔드를 사용하는 예제입니다. 데이터베이스는 MySQL을 사용하며 빌드 도구로는 Gradle을 사용합니다.
+
+## 백엔드 설정
+
+1. JDK 17 이상을 설치합니다.
+2. 로컬 MySQL 서버를 준비하고 `src/main/resources/application.properties`의 접속 정보를 수정합니다.
+3. 프로젝트 루트에서 다음 명령으로 테스트 및 빌드를 수행할 수 있습니다.
+   ```bash
+   gradle build
+   ```
+
+## 프론트엔드 설정
+
+1. Node.js 16 이상과 npm을 설치합니다.
+2. `frontend` 디렉터리에서 의존성을 설치하고 개발 서버를 실행합니다.
+   ```bash
+   cd frontend
+   npm install
+   npm run serve
+   ```
+
+## 프로젝트 구조
+
+- `build.gradle` & `settings.gradle`: Spring Boot Gradle 설정
+- `src/main/java`: 백엔드 Java 코드
+- `frontend`: Vue 2 프론트엔드 코드
+
+초기 환경 구성이 완료되면 백엔드와 프론트엔드 개발을 진행할 수 있습니다.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.5'
+    id 'java'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '17'
+
+defaultTasks 'build'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'mysql:mysql-connector-java:8.0.33'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "springvue2-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "serve": "vue-cli-service serve",
+    "build": "vue-cli-service build"
+  },
+  "dependencies": {
+    "vue": "^2.7.14"
+  },
+  "devDependencies": {
+    "@vue/cli-service": "^5.0.8"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>SpringVue2</title>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,11 @@
+<template>
+  <div id="app">
+    <h1>Hello SpringVue2!</h1>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'App'
+}
+</script>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,8 @@
+import Vue from 'vue'
+import App from './App.vue'
+
+Vue.config.productionTip = false
+
+new Vue({
+  render: h => h(App),
+}).$mount('#app')

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  devServer: {
+    port: 8081,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      }
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "springvue2",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "serve": "npm --prefix frontend run serve"
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'springvue2'

--- a/src/main/java/com/example/springvue2/Springvue2Application.java
+++ b/src/main/java/com/example/springvue2/Springvue2Application.java
@@ -1,0 +1,11 @@
+package com.example.springvue2;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Springvue2Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Springvue2Application.class, args);
+    }
+}

--- a/src/main/java/com/example/springvue2/config/WebConfig.java
+++ b/src/main/java/com/example/springvue2/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.example.springvue2.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:8081")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,6 @@ spring.datasource.url=jdbc:mysql://localhost:3306/mydb
 spring.datasource.username=root
 spring.datasource.password=pass
 spring.jpa.hibernate.ddl-auto=update
+
+# Spring Boot server port
+server.port=8080

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:mysql://localhost:3306/mydb
+spring.datasource.username=root
+spring.datasource.password=pass
+spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/example/springvue2/Springvue2ApplicationTests.java
+++ b/src/test/java/com/example/springvue2/Springvue2ApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.springvue2;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class Springvue2ApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- set up basic Gradle build for Spring Boot
- add Vue 2 frontend skeleton
- document how to set up backend and frontend environments
- ignore build and node modules folders

## Testing
- `gradle test` *(fails: plugin not found due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_6880db622d9483209117b37616ef9481